### PR TITLE
The Scroll and Search Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "typescript": "^4.7.4"
     },
     "dependencies": {
-        "decky-frontend-lib": "^1.1.0",
+        "decky-frontend-lib": "^1.2.4",
         "dompurify": "^2.3.9",
         "html-react-parser": "^3.0.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "prettier": "2.7.1",
         "rollup": "^2.75.7",
         "rollup-plugin-import-assets": "^1.1.1",
+        "rollup-plugin-terser": "^7.0.2",
         "tslib": "^2.4.0",
         "typescript": "^4.7.4"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ specifiers:
   react-icons: ^4.4.0
   rollup: ^2.75.7
   rollup-plugin-import-assets: ^1.1.1
+  rollup-plugin-terser: ^7.0.2
   tslib: ^2.4.0
   typescript: ^4.7.4
 
@@ -41,10 +42,69 @@ devDependencies:
   prettier: 2.7.1
   rollup: 2.75.7
   rollup-plugin-import-assets: 1.1.1_rollup@2.75.7
+  rollup-plugin-terser: 7.0.2_rollup@2.75.7
   tslib: 2.4.0
   typescript: 4.7.4
 
 packages:
+
+  /@babel/code-frame/7.18.6:
+    resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.18.6
+    dev: true
+
+  /@babel/helper-validator-identifier/7.18.6:
+    resolution: {integrity: sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/highlight/7.18.6:
+    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.18.6
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+
+  /@jridgewell/gen-mapping/0.3.2:
+    resolution: {integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/set-array': 1.1.2
+      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/trace-mapping': 0.3.14
+    dev: true
+
+  /@jridgewell/resolve-uri/3.1.0:
+    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/set-array/1.1.2:
+    resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/source-map/0.3.2:
+    resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/trace-mapping': 0.3.14
+    dev: true
+
+  /@jridgewell/sourcemap-codec/1.4.14:
+    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+    dev: true
+
+  /@jridgewell/trace-mapping/0.3.14:
+    resolution: {integrity: sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
 
   /@rollup/plugin-commonjs/22.0.1_rollup@2.75.7:
     resolution: {integrity: sha512-dGfEZvdjDHObBiP5IvwTKMVeq/tBZGMBHZFMdIV1ClMM/YoWS34xrHFGfag9SN2ZtMgNZRFruqvxZQEa70O6nQ==}
@@ -176,6 +236,19 @@ packages:
     resolution: {integrity: sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==}
     dev: true
 
+  /acorn/8.8.0:
+    resolution: {integrity: sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /ansi-styles/3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+    dependencies:
+      color-convert: 1.9.3
+    dev: true
+
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -187,9 +260,36 @@ packages:
       concat-map: 0.0.1
     dev: true
 
+  /buffer-from/1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: true
+
   /builtin-modules/3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
+    dev: true
+
+  /chalk/2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+    dev: true
+
+  /color-convert/1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    dependencies:
+      color-name: 1.1.3
+    dev: true
+
+  /color-name/1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    dev: true
+
+  /commander/2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
 
   /commondir/1.0.1:
@@ -249,6 +349,11 @@ packages:
     engines: {node: '>=0.12'}
     dev: false
 
+  /escape-string-regexp/1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+    dev: true
+
   /estree-walker/0.6.1:
     resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
     dev: true
@@ -286,6 +391,16 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+    dev: true
+
+  /has-flag/3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /has-flag/4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
     dev: true
 
   /has/1.0.3:
@@ -361,9 +476,17 @@ packages:
       '@types/estree': 0.0.52
     dev: true
 
+  /jest-worker/26.6.2:
+    resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
+    engines: {node: '>= 10.13.0'}
+    dependencies:
+      '@types/node': 18.0.0
+      merge-stream: 2.0.0
+      supports-color: 7.2.0
+    dev: true
+
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-    dev: false
 
   /loose-envify/1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -376,6 +499,10 @@ packages:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
+    dev: true
+
+  /merge-stream/2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
     dev: true
 
   /minimatch/3.1.2:
@@ -408,6 +535,12 @@ packages:
     resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+    dev: true
+
+  /randombytes/2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+    dependencies:
+      safe-buffer: 5.2.1
     dev: true
 
   /react-dom/18.2.0_react@18.2.0:
@@ -458,6 +591,18 @@ packages:
       url-join: 4.0.1
     dev: true
 
+  /rollup-plugin-terser/7.0.2_rollup@2.75.7:
+    resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
+    peerDependencies:
+      rollup: ^2.0.0
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      jest-worker: 26.6.2
+      rollup: 2.75.7
+      serialize-javascript: 4.0.0
+      terser: 5.14.2
+    dev: true
+
   /rollup-pluginutils/2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
     dependencies:
@@ -472,11 +617,33 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /safe-buffer/5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: true
+
   /scheduler/0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
     dependencies:
       loose-envify: 1.4.0
     dev: false
+
+  /serialize-javascript/4.0.0:
+    resolution: {integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==}
+    dependencies:
+      randombytes: 2.1.0
+    dev: true
+
+  /source-map-support/0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    dev: true
+
+  /source-map/0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
@@ -494,9 +661,34 @@ packages:
       inline-style-parser: 0.1.1
     dev: false
 
+  /supports-color/5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+    dependencies:
+      has-flag: 3.0.0
+    dev: true
+
+  /supports-color/7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: true
+
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+    dev: true
+
+  /terser/5.14.2:
+    resolution: {integrity: sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/source-map': 0.3.2
+      acorn: 8.8.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
     dev: true
 
   /tslib/2.4.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   '@types/dompurify': ^2.3.3
   '@types/react': ^17.0.47
   '@types/react-dom': ^18.0.5
-  decky-frontend-lib: ^1.1.0
+  decky-frontend-lib: ^1.2.4
   dompurify: ^2.3.9
   html-react-parser: ^3.0.0
   prettier: 2.7.1
@@ -22,7 +22,7 @@ specifiers:
   typescript: ^4.7.4
 
 dependencies:
-  decky-frontend-lib: 1.1.0
+  decky-frontend-lib: 1.2.4
   dompurify: 2.3.9
   html-react-parser: 3.0.0_react@18.2.0
   react: 18.2.0
@@ -204,8 +204,8 @@ packages:
     resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
     dev: true
 
-  /decky-frontend-lib/1.1.0:
-    resolution: {integrity: sha512-wMDHMAM4ycR4hUfRQf16GxgxwkWpcTnaR712cljLrTCzGJVQp1IZuejss1eHf0dviv77VYkVp0s9QW2BIlakmQ==}
+  /decky-frontend-lib/1.2.4:
+    resolution: {integrity: sha512-r3mLEey9KUkF68geJVSjNlOz/Fg4vpMKUzoutSceyd8o/J5l+QR+Vf0b3gwK3UN9Sp4Pj4XQ1eB82+/W0ApsFg==}
     dev: false
 
   /deepmerge/4.2.2:

--- a/release.md
+++ b/release.md
@@ -1,11 +1,7 @@
-### DeckFAQs, a GameFAQs browser for the Steam Deck (v1.2.1)
+## DeckFAQs, a GameFAQs browser for the Steam Deck (v1.3)
 
--   **BUGFIX** Fix an issue where guides in the list can get duplicated
--   Loading indicator added when data is loading
--   Renders guide directly in side panel instead of through iframes
--   Scrolling to anchor points in HTML guides added
--   Adds Table of Contents for HTML based guides
--   Better fullscreen guide support
--   Dark Mode preference (preference remembered across sessions of using DeckFAQs)
--   Possibly some other stuff I forgot because I spent too long working on this
+### The scroll and search update!
+
+-   Adds the ability to search plain-text guides in the quick access menu. Search is supported for all guides in fullscreen view. Search is case insensitive.
+-   Adds scrolling of guides with the gamepad. Scrolling works with either the joystick or dpad. Guide must have focus (click the guide with the A button). Focus can be removed by pressing B.
 -   _NOTE:_ This version (and any version >= 1.0.0) is not compatible with the original PluginLoader. You must use the "Decky Loader" which is the react based plugin loader

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import replace from '@rollup/plugin-replace';
 import typescript from '@rollup/plugin-typescript';
 import { defineConfig } from 'rollup';
 import importAssets from 'rollup-plugin-import-assets';
-
+import { terser } from 'rollup-plugin-terser';
 import { name } from './plugin.json';
 
 export default defineConfig({
@@ -33,5 +33,6 @@ export default defineConfig({
         },
         format: 'iife',
         exports: 'default',
+        plugins: [terser({ mangle: false, compress: false })],
     },
 });

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -165,13 +165,12 @@ export const App = ({ serverApi }: DefaultProps) => {
         <div
             style={{
                 height: '395px',
-                padding: '0 16px',
                 display: 'flex',
                 flexFlow: 'column',
             }}
         >
             <Nav serverApi={serverApi} />
-            <div ref={mainDiv} style={{ flexGrow: '1', overflow: 'auto' }}>
+            <div ref={mainDiv} style={{ padding: '10px', overflow: 'auto' }}>
                 <MainView serverApi={serverApi} />
             </div>
         </div>

--- a/src/components/EmptyModal.tsx
+++ b/src/components/EmptyModal.tsx
@@ -1,0 +1,16 @@
+import { ModalRootProps } from 'decky-frontend-lib';
+import { findModuleChild } from 'decky-frontend-lib';
+import { FC } from 'react';
+
+export const EmptyModal = findModuleChild((m) => {
+    if (typeof m !== 'object') return undefined;
+    for (let prop in m) {
+        if (
+            m[prop]?.prototype?.OK &&
+            m[prop]?.prototype?.Cancel &&
+            m[prop]?.prototype?.render
+        ) {
+            return m[prop];
+        }
+    }
+}) as FC<ModalRootProps>;

--- a/src/components/EmptyModal.tsx
+++ b/src/components/EmptyModal.tsx
@@ -1,5 +1,4 @@
-import { ModalRootProps } from 'decky-frontend-lib';
-import { findModuleChild } from 'decky-frontend-lib';
+import { ModalRootProps, findModuleChild } from 'decky-frontend-lib';
 import { FC } from 'react';
 
 export const EmptyModal = findModuleChild((m) => {

--- a/src/components/Guide/Guide.tsx
+++ b/src/components/Guide/Guide.tsx
@@ -24,9 +24,20 @@ type GuideProps = DefaultProps & {
     fullscreen?: boolean;
 };
 
+function createUUID() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(
+        /[xy]/g,
+        function (c) {
+            var r = (Math.random() * 16) | 0,
+                v = c == 'x' ? r : (r & 0x3) | 0x8;
+            return v.toString(16);
+        }
+    );
+}
+
 export const Guide = ({ serverApi, fullscreen }: GuideProps) => {
     const { state, dispatch } = useContext(AppContext);
-    const { currentGuide, isLoading } = state;
+    const { currentGuide, search, isLoading } = state;
     const guideDiv = useRef<HTMLDivElement>(null);
     const stateRef = useRef(state);
 
@@ -159,12 +170,43 @@ export const Guide = ({ serverApi, fullscreen }: GuideProps) => {
         }
     };
 
+    useEffect(() => {
+        if (guideDiv.current && search) {
+            const { searchText, searchIndex } = search;
+            let index = guideDiv.current.innerText.indexOf(
+                searchText,
+                searchIndex
+            );
+            if (index >= 0) {
+                // dispatch({
+                //     type: ActionType.UPDATE_SEARCH_TEXT,
+                //     payload: {
+                //         searchText,
+                //         searchIndex: index,
+                //     },
+                // });
+                const id = createUUID();
+                console.log('found');
+                guideDiv.current.innerHTML = guideDiv.current.innerHTML.replace(
+                    searchText,
+                    `<span id="${id}" class="deckfaqs_highlight">${searchText}</span>`
+                );
+                guideDiv.current
+                    ?.querySelector(`[id="${id}"]`)
+                    ?.scrollIntoView();
+            }
+        }
+    }, [search]);
+
     let cssId: any = '';
     useEffect(() => {
         serverApi
             .injectCssIntoTab(
                 !fullscreen ? 'QuickAccess' : 'SP',
                 `
+              .deckfaqs_highlight {
+                background-color: #FFFF00; 
+              }
               .deckfaqs_dark {
                 filter: invert(1)
               }

--- a/src/components/Guide/Guide.tsx
+++ b/src/components/Guide/Guide.tsx
@@ -19,6 +19,7 @@ import parse, {
 import { ActionType } from '../../reducers/AppReducer';
 import { DefaultProps, getGuideHtml } from '../../utils';
 import { TocDropdown } from '../Nav/TocDropdown';
+import { Search } from '../Nav/Search';
 
 type GuideProps = DefaultProps & {
     fullscreen?: boolean;
@@ -626,9 +627,7 @@ export const Guide = ({ serverApi, fullscreen }: GuideProps) => {
 };
 
 const navButtonStyle = {
-    height: '40px',
     width: '200px',
-    minWidth: '0',
     padding: '10px 12px',
 };
 
@@ -667,10 +666,10 @@ const FullScreenGuide = ({ serverApi, onDismiss }: FullScreenGuideProps) => {
                     display: 'flex',
                 }}
             >
-                <Focusable style={{ display: 'flex' }}>
+                <Focusable style={{ display: 'flex', width: '100%' }}>
                     {Router.MainRunningApp !== undefined && (
                         <DialogButton
-                            style={{ ...navButtonStyle, marginRight: '10px' }}
+                            style={{ minWidth: '0px', marginRight: '10px' }}
                             onClick={() => {
                                 Router.NavigateBackOrOpenMenu();
                                 setTimeout(
@@ -699,8 +698,15 @@ const FullScreenGuide = ({ serverApi, onDismiss }: FullScreenGuideProps) => {
                     </DialogButton>
                     {state.currentGuide &&
                         state.currentGuide.guideToc!.length > 0 && (
-                            <TocDropdown serverApi={serverApi} />
+                            <TocDropdown
+                                style={{
+                                    minWidth: '200px',
+                                    marginRight: '10px',
+                                }}
+                                serverApi={serverApi}
+                            />
                         )}
+                    <Search fullScreen={true} />
                 </Focusable>
             </div>
             <Guide fullscreen={true} serverApi={serverApi} />

--- a/src/components/Guide/Guide.tsx
+++ b/src/components/Guide/Guide.tsx
@@ -690,15 +690,15 @@ const FullScreenGuide = ({ serverApi, onDismiss }: FullScreenGuideProps) => {
         >
             <div
                 style={{
-                    marginBottom: '10px',
-                    marginLeft: '10px',
-                    marginRight: '10px',
+                    margin: '0 10px',
                     display: 'flex',
                 }}
             >
                 <Focusable style={{ display: 'flex', width: '100%' }}>
                     {Router.MainRunningApp !== undefined && (
                         <DialogButton
+                            //@ts-ignore
+                            disableNavSounds={true}
                             style={{ minWidth: '0px', marginRight: '10px' }}
                             onClick={() => {
                                 Router.NavigateBackOrOpenMenu();
@@ -712,6 +712,8 @@ const FullScreenGuide = ({ serverApi, onDismiss }: FullScreenGuideProps) => {
                         </DialogButton>
                     )}
                     <DialogButton
+                        //@ts-ignore
+                        disableNavSounds={true}
                         style={{ ...navButtonStyle, marginRight: '10px' }}
                         onClick={() => {
                             Router.NavigateBackOrOpenMenu();

--- a/src/components/Guide/mark.ts
+++ b/src/components/Guide/mark.ts
@@ -1,0 +1,718 @@
+/**
+ * Forked from mark.js v8.9.0 (https://github.com/Gijsjan/mark.js)
+ *  - https://github.com/julmot/mark.js
+ *  - Copyright (c) 2014–2017, Julian Motz
+ * Released under the MIT license https://git.io/vwTVl
+ */
+
+// @ts-nocheck
+class Mark {
+    // eslint-disable-line no-unused-vars
+    private ctx;
+    private ie;
+    private _opt;
+    private _iterator;
+
+    constructor(ctx) {
+        this.ctx = ctx;
+
+        this.ie = false;
+        const ua = window.navigator.userAgent;
+        if (ua.indexOf('MSIE') > -1 || ua.indexOf('Trident') > -1) {
+            this.ie = true;
+        }
+    }
+
+    set opt(val) {
+        this._opt = Object.assign(
+            {},
+            {
+                element: '',
+                className: '',
+                exclude: [],
+                separateWordSearch: true,
+                diacritics: true,
+                synonyms: {},
+                accuracy: 'partially',
+                acrossElements: false,
+                caseSensitive: false,
+                ignoreJoiners: false,
+                ignoreGroups: 0,
+                wildcards: 'disabled',
+                each: () => {},
+                noMatch: () => {},
+                filter: () => true,
+                done: () => {},
+                debug: false,
+                log: window.console,
+            },
+            val
+        );
+    }
+
+    get opt() {
+        return this._opt;
+    }
+
+    get iterator() {
+        if (!this._iterator) {
+            this._iterator = new DOMIterator(this.ctx, this.opt.exclude);
+        }
+        return this._iterator;
+    }
+
+    log(msg, level = 'debug') {
+        const log = this.opt.log;
+        if (!this.opt.debug) {
+            return;
+        }
+        if (typeof log === 'object' && typeof log[level] === 'function') {
+            log[level](`mark.js: ${msg}`);
+        }
+    }
+
+    escapeStr(str) {
+        return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+    }
+
+    createRegExp(str) {
+        if (this.opt.wildcards !== 'disabled') {
+            str = this.setupWildcardsRegExp(str);
+        }
+        str = this.escapeStr(str);
+        if (Object.keys(this.opt.synonyms).length) {
+            str = this.createSynonymsRegExp(str);
+        }
+        if (this.opt.ignoreJoiners) {
+            str = this.setupIgnoreJoinersRegExp(str);
+        }
+        if (this.opt.diacritics) {
+            str = this.createDiacriticsRegExp(str);
+        }
+        str = this.createMergedBlanksRegExp(str);
+        if (this.opt.ignoreJoiners) {
+            str = this.createIgnoreJoinersRegExp(str);
+        }
+        if (this.opt.wildcards !== 'disabled') {
+            str = this.createWildcardsRegExp(str);
+        }
+        str = this.createAccuracyRegExp(str);
+        return str;
+    }
+
+    createSynonymsRegExp(str) {
+        const syn = this.opt.synonyms,
+            sens = this.opt.caseSensitive ? '' : 'i';
+        for (let index in syn) {
+            if (syn.hasOwnProperty(index)) {
+                const value = syn[index],
+                    k1 =
+                        this.opt.wildcards !== 'disabled'
+                            ? this.setupWildcardsRegExp(index)
+                            : this.escapeStr(index),
+                    k2 =
+                        this.opt.wildcards !== 'disabled'
+                            ? this.setupWildcardsRegExp(value)
+                            : this.escapeStr(value);
+                if (k1 !== '' && k2 !== '') {
+                    str = str.replace(
+                        new RegExp(`(${k1}|${k2})`, `gm${sens}`),
+                        `(${k1}|${k2})`
+                    );
+                }
+            }
+        }
+        return str;
+    }
+
+    setupWildcardsRegExp(str) {
+        // replace single character wildcard with unicode 0001
+        str = str.replace(/(?:\\)*\?/g, (val) => {
+            return val.charAt(0) === '\\' ? '?' : '\u0001';
+        });
+        // replace multiple character wildcard with unicode 0002
+        return str.replace(/(?:\\)*\*/g, (val) => {
+            return val.charAt(0) === '\\' ? '*' : '\u0002';
+        });
+    }
+
+    createWildcardsRegExp(str) {
+        // default to "enable" (i.e. to not include spaces)
+        // "withSpaces" uses `[\\S\\s]` instead of `.` because the latter
+        // does not match new line characters
+        let spaces = this.opt.wildcards === 'withSpaces';
+        return (
+            str
+                // replace unicode 0001 with a RegExp class to match any single
+                // character, or any single non-whitespace character depending
+                // on the setting
+                .replace(/\u0001/g, spaces ? '[\\S\\s]?' : '\\S?')
+                // replace unicode 0002 with a RegExp class to match zero or
+                // more characters, or zero or more non-whitespace characters
+                // depending on the setting
+                .replace(/\u0002/g, spaces ? '[\\S\\s]*?' : '\\S*')
+        );
+    }
+
+    setupIgnoreJoinersRegExp(str) {
+        // adding a "null" unicode character as it will not be modified by the
+        // other "create" regular expression functions
+        return str.replace(/[^(|)\\]/g, (val, indx, original) => {
+            // don't add a null after an opening "(", around a "|" or before
+            // a closing "(", or between an escapement (e.g. \+)
+            let nextChar = original.charAt(indx + 1);
+            if (/[(|)\\]/.test(nextChar) || nextChar === '') {
+                return val;
+            } else {
+                return val + '\u0000';
+            }
+        });
+    }
+
+    createIgnoreJoinersRegExp(str) {
+        // u+00ad = soft hyphen
+        // u+200b = zero-width space
+        // u+200c = zero-width non-joiner
+        // u+200d = zero-width joiner
+        return str.split('\u0000').join('[\\u00ad|\\u200b|\\u200c|\\u200d]?');
+    }
+
+    createDiacriticsRegExp(str) {
+        const sens = this.opt.caseSensitive ? '' : 'i';
+        const dct = this.opt.caseSensitive
+            ? [
+                  'aàáâãäåāąă',
+                  'AÀÁÂÃÄÅĀĄĂ',
+                  'cçćč',
+                  'CÇĆČ',
+                  'dđď',
+                  'DĐĎ',
+                  'eèéêëěēę',
+                  'EÈÉÊËĚĒĘ',
+                  'iìíîïī',
+                  'IÌÍÎÏĪ',
+                  'lł',
+                  'LŁ',
+                  'nñňń',
+                  'NÑŇŃ',
+                  'oòóôõöøō',
+                  'OÒÓÔÕÖØŌ',
+                  'rř',
+                  'RŘ',
+                  'sšśșş',
+                  'SŠŚȘŞ',
+                  'tťțţ',
+                  'TŤȚŢ',
+                  'uùúûüůū',
+                  'UÙÚÛÜŮŪ',
+                  'yÿý',
+                  'YŸÝ',
+                  'zžżź',
+                  'ZŽŻŹ',
+              ]
+            : [
+                  'aàáâãäåāąăAÀÁÂÃÄÅĀĄĂ',
+                  'cçćčCÇĆČ',
+                  'dđďDĐĎ',
+                  'eèéêëěēęEÈÉÊËĚĒĘ',
+                  'iìíîïīIÌÍÎÏĪ',
+                  'lłLŁ',
+                  'nñňńNÑŇŃ',
+                  'oòóôõöøōOÒÓÔÕÖØŌ',
+                  'rřRŘ',
+                  'sšśșşSŠŚȘŞ',
+                  'tťțţTŤȚŢ',
+                  'uùúûüůūUÙÚÛÜŮŪ',
+                  'yÿýYŸÝ',
+                  'zžżźZŽŻŹ',
+              ];
+        const handled = [];
+        str.split('').forEach((ch) => {
+            dct.every((dct) => {
+                // Check if the character is inside a diacritics list
+                if (dct.indexOf(ch) !== -1) {
+                    // Check if the related diacritics list was not
+                    // handled yet
+                    if (handled.indexOf(dct) > -1) {
+                        return false;
+                    }
+                    // Make sure that the character OR any other
+                    // character in the diacritics list will be matched
+                    str = str.replace(
+                        new RegExp(`[${dct}]`, `gm${sens}`),
+                        `[${dct}]`
+                    );
+                    handled.push(dct);
+                }
+                return true;
+            });
+        });
+        return str;
+    }
+
+    createMergedBlanksRegExp(str) {
+        return str.replace(/[\s]+/gim, '[\\s]+');
+    }
+
+    createAccuracyRegExp(str) {
+        const chars = `!"#$%&'()*+,-./:;<=>?@[\\]^_\`{|}~¡¿`;
+        let acc = this.opt.accuracy,
+            val = typeof acc === 'string' ? acc : acc.value,
+            ls = typeof acc === 'string' ? [] : acc.limiters,
+            lsJoin = '';
+        ls.forEach((limiter) => {
+            lsJoin += `|${this.escapeStr(limiter)}`;
+        });
+        switch (val) {
+            case 'partially':
+            default:
+                return `()(${str})`;
+            case 'complementary':
+                lsJoin = '\\s' + (lsJoin ? lsJoin : this.escapeStr(chars));
+                return `()([^${lsJoin}]*${str}[^${lsJoin}]*)`;
+            case 'exactly':
+                return `(^|\\s${lsJoin})(${str})(?=$|\\s${lsJoin})`;
+        }
+    }
+
+    getSeparatedKeywords(sv) {
+        let stack = [];
+        sv.forEach((kw) => {
+            if (!this.opt.separateWordSearch) {
+                if (kw.trim() && stack.indexOf(kw) === -1) {
+                    stack.push(kw);
+                }
+            } else {
+                kw.split(' ').forEach((kwSplitted) => {
+                    if (kwSplitted.trim() && stack.indexOf(kwSplitted) === -1) {
+                        stack.push(kwSplitted);
+                    }
+                });
+            }
+        });
+        return {
+            // sort because of https://git.io/v6USg
+            keywords: stack.sort((a, b) => {
+                return b.length - a.length;
+            }),
+            length: stack.length,
+        };
+    }
+
+    getTextNodes(cb) {
+        let val = '',
+            nodes = [];
+        this.iterator.forEachNode(
+            NodeFilter.SHOW_TEXT,
+            (node) => {
+                nodes.push({
+                    start: val.length,
+                    end: (val += node.textContent).length,
+                    node,
+                });
+            },
+            (node) => {
+                if (this.matchesExclude(node.parentNode)) {
+                    return NodeFilter.FILTER_REJECT;
+                } else {
+                    return NodeFilter.FILTER_ACCEPT;
+                }
+            },
+            () => {
+                cb({
+                    value: val,
+                    nodes: nodes,
+                });
+            }
+        );
+    }
+
+    matchesExclude(el) {
+        return DOMIterator.matches(
+            el,
+            this.opt.exclude.concat([
+                // ignores the elements itself, not their childrens (selector *)
+                'script',
+                'style',
+                'title',
+                'head',
+                'html',
+            ])
+        );
+    }
+
+    wrapRangeInTextNode(node, start, end) {
+        const hEl = !this.opt.element ? 'mark' : this.opt.element,
+            startNode = node.splitText(start),
+            ret = startNode.splitText(end - start);
+        let repl = document.createElement(hEl);
+        repl.setAttribute('data-markjs', 'true');
+        if (this.opt.className) {
+            repl.setAttribute('class', this.opt.className);
+        }
+        repl.textContent = startNode.textContent;
+        startNode.parentNode.replaceChild(repl, startNode);
+        return ret;
+    }
+
+    wrapRangeInMappedTextNode(dict, start, end, filterCb, eachCb) {
+        // iterate over all text nodes to find the one matching the positions
+        dict.nodes.every((n, i) => {
+            const sibl = dict.nodes[i + 1];
+            if (typeof sibl === 'undefined' || sibl.start > start) {
+                if (!filterCb(n.node)) {
+                    return false;
+                }
+                // map range from dict.value to text node
+                const s = start - n.start,
+                    e = (end > n.end ? n.end : end) - n.start,
+                    startStr = dict.value.substr(0, n.start),
+                    endStr = dict.value.substr(e + n.start);
+                n.node = this.wrapRangeInTextNode(n.node, s, e);
+                // recalculate positions to also find subsequent matches in the
+                // same text node. Necessary as the text node in dict now only
+                // contains the splitted part after the wrapped one
+                dict.value = startStr + endStr;
+                dict.nodes.forEach((k, j) => {
+                    if (j >= i) {
+                        if (dict.nodes[j].start > 0 && j !== i) {
+                            dict.nodes[j].start -= e;
+                        }
+                        dict.nodes[j].end -= e;
+                    }
+                });
+                end -= e;
+                eachCb(n.node.previousSibling, n.start);
+                if (end > n.end) {
+                    start = n.end;
+                } else {
+                    return false;
+                }
+            }
+            return true;
+        });
+    }
+
+    wrapMatches(regex, ignoreGroups, filterCb, eachCb, endCb) {
+        const matchIdx = ignoreGroups === 0 ? 0 : ignoreGroups + 1;
+        this.getTextNodes((dict) => {
+            dict.nodes.forEach((node) => {
+                node = node.node;
+                let match;
+                while (
+                    (match = regex.exec(node.textContent)) !== null &&
+                    match[matchIdx] !== ''
+                ) {
+                    if (!filterCb(match[matchIdx], node)) {
+                        continue;
+                    }
+                    let pos = match.index;
+                    if (matchIdx !== 0) {
+                        for (let i = 1; i < matchIdx; i++) {
+                            pos += match[i].length;
+                        }
+                    }
+                    node = this.wrapRangeInTextNode(
+                        node,
+                        pos,
+                        pos + match[matchIdx].length
+                    );
+                    eachCb(node.previousSibling);
+                    // reset index of last match as the node changed and the
+                    // index isn't valid anymore http://tinyurl.com/htsudjd
+                    regex.lastIndex = 0;
+                }
+            });
+            endCb();
+        });
+    }
+
+    wrapMatchesAcrossElements(regex, ignoreGroups, filterCb, eachCb, endCb) {
+        const matchIdx = ignoreGroups === 0 ? 0 : ignoreGroups + 1;
+        this.getTextNodes((dict) => {
+            let match;
+            while (
+                (match = regex.exec(dict.value)) !== null &&
+                match[matchIdx] !== ''
+            ) {
+                // calculate range inside dict.value
+                let start = match.index;
+                if (matchIdx !== 0) {
+                    for (let i = 1; i < matchIdx; i++) {
+                        start += match[i].length;
+                    }
+                }
+                const end = start + match[matchIdx].length;
+                // note that dict will be updated automatically, as it'll change
+                // in the wrapping process, due to the fact that text
+                // nodes will be splitted
+                this.wrapRangeInMappedTextNode(
+                    dict,
+                    start,
+                    end,
+                    (node) => {
+                        return filterCb(match[matchIdx], node);
+                    },
+                    (node, lastIndex) => {
+                        regex.lastIndex = lastIndex;
+                        eachCb(node);
+                    }
+                );
+            }
+            endCb();
+        });
+    }
+
+    unwrapMatches(node) {
+        const parent = node.parentNode;
+        let docFrag = document.createDocumentFragment();
+        while (node.firstChild) {
+            docFrag.appendChild(node.removeChild(node.firstChild));
+        }
+        parent.replaceChild(docFrag, node);
+        if (!this.ie) {
+            // use browser's normalize method
+            parent.normalize();
+        } else {
+            // custom method (needs more time)
+            this.normalizeTextNode(parent);
+        }
+    }
+
+    normalizeTextNode(node) {
+        if (!node) {
+            return;
+        }
+        if (node.nodeType === 3) {
+            while (node.nextSibling && node.nextSibling.nodeType === 3) {
+                node.nodeValue += node.nextSibling.nodeValue;
+                node.parentNode.removeChild(node.nextSibling);
+            }
+        } else {
+            this.normalizeTextNode(node.firstChild);
+        }
+        this.normalizeTextNode(node.nextSibling);
+    }
+
+    markRegExp(regexp, opt) {
+        this.opt = opt;
+        this.log(`Searching with expression "${regexp}"`);
+        let totalMatches = 0,
+            fn = 'wrapMatches';
+        const eachCb = (element) => {
+            totalMatches++;
+            this.opt.each(element);
+        };
+        if (this.opt.acrossElements) {
+            fn = 'wrapMatchesAcrossElements';
+        }
+        this[fn](
+            regexp,
+            this.opt.ignoreGroups,
+            (match, node) => {
+                return this.opt.filter(node, match, totalMatches);
+            },
+            eachCb,
+            () => {
+                if (totalMatches === 0) {
+                    this.opt.noMatch(regexp);
+                }
+                this.opt.done(totalMatches);
+            }
+        );
+    }
+
+    mark(sv, opt) {
+        this.opt = opt;
+        let totalMatches = 0;
+        const i = this.opt.caseSensitive ? '' : 'i';
+        const fn = this.opt.acrossElements
+            ? 'wrapMatchesAcrossElements'
+            : 'wrapMatches';
+        const { keywords: kwArr, length: kwArrLen } = this.getSeparatedKeywords(
+            typeof sv === 'string' ? [sv] : sv
+        );
+        if (!kwArrLen) return this.opt.done(totalMatches);
+
+        const handler = (kw) => {
+            // async function calls as iframes are async too
+            let regex = new RegExp(this.createRegExp(kw), `gm${i}`);
+            let matches = 0;
+            this.log(`Searching with expression "${regex}"`);
+
+            const filterCb = (term, node) =>
+                this.opt.filter(node, kw, totalMatches, matches);
+            const eachCb = (element) => {
+                matches++;
+                totalMatches++;
+                this.opt.each(element);
+            };
+            const endCb = () => {
+                if (matches === 0) {
+                    this.opt.noMatch(kw);
+                }
+                if (kwArr[kwArrLen - 1] === kw) {
+                    this.opt.done(totalMatches);
+                } else {
+                    handler(kwArr[kwArr.indexOf(kw) + 1]);
+                }
+            };
+
+            this[fn](regex, 1, filterCb, eachCb, endCb);
+        };
+
+        handler(kwArr[0]);
+    }
+
+    unmark(opt) {
+        this.opt = opt;
+        let sel = this.opt.element ? this.opt.element : '*';
+        sel += '[data-markjs]';
+        if (this.opt.className) {
+            sel += `.${this.opt.className}`;
+        }
+        this.log(`Removal selector "${sel}"`);
+        this.iterator.forEachNode(
+            NodeFilter.SHOW_ELEMENT,
+            (node) => {
+                this.unwrapMatches(node);
+            },
+            (node) => {
+                const matchesSel = DOMIterator.matches(node, sel),
+                    matchesExclude = this.matchesExclude(node);
+                if (!matchesSel || matchesExclude) {
+                    return NodeFilter.FILTER_REJECT;
+                } else {
+                    return NodeFilter.FILTER_ACCEPT;
+                }
+            },
+            this.opt.done
+        );
+    }
+}
+
+class DOMIterator {
+    private ctx;
+    private exclude;
+
+    constructor(ctx, exclude = []) {
+        this.ctx = ctx;
+        this.exclude = exclude;
+    }
+
+    static matches(element, selector) {
+        const selectors = typeof selector === 'string' ? [selector] : selector,
+            fn =
+                element.matches ||
+                element.matchesSelector ||
+                element.msMatchesSelector ||
+                element.mozMatchesSelector ||
+                element.oMatchesSelector ||
+                element.webkitMatchesSelector;
+        if (fn) {
+            let match = false;
+            selectors.every((sel) => {
+                if (fn.call(element, sel)) {
+                    match = true;
+                    return false;
+                }
+                return true;
+            });
+            return match;
+        } else {
+            // may be false e.g. when el is a textNode
+            return false;
+        }
+    }
+
+    getContexts() {
+        let ctx,
+            filteredCtx = [];
+        if (typeof this.ctx === 'undefined' || !this.ctx) {
+            // e.g. null
+            ctx = [];
+        } else if (NodeList.prototype.isPrototypeOf(this.ctx)) {
+            ctx = Array.prototype.slice.call(this.ctx);
+        } else if (Array.isArray(this.ctx)) {
+            ctx = this.ctx;
+        } else if (typeof this.ctx === 'string') {
+            ctx = Array.prototype.slice.call(
+                document.querySelectorAll(this.ctx)
+            );
+        } else {
+            // e.g. HTMLElement or element inside iframe
+            ctx = [this.ctx];
+        }
+        // filter duplicate text nodes
+        ctx.forEach((ctx) => {
+            const isDescendant =
+                filteredCtx.filter((contexts) => {
+                    return contexts.contains(ctx);
+                }).length > 0;
+            if (filteredCtx.indexOf(ctx) === -1 && !isDescendant) {
+                filteredCtx.push(ctx);
+            }
+        });
+        return filteredCtx;
+    }
+
+    createIterator(ctx, whatToShow, filter) {
+        return document.createNodeIterator(ctx, whatToShow, filter, false);
+    }
+
+    getIteratorNode(itr) {
+        const prevNode = itr.previousNode();
+        let node;
+        if (prevNode === null) {
+            node = itr.nextNode();
+        } else {
+            node = itr.nextNode() && itr.nextNode();
+        }
+        return {
+            prevNode,
+            node,
+        };
+    }
+
+    iterateThroughNodes(whatToShow, ctx, eachCb, filterCb, doneCb) {
+        const itr = this.createIterator(ctx, whatToShow, filterCb);
+
+        let elements = [];
+        let node;
+
+        const retrieveNodes = () => {
+            const result = this.getIteratorNode(itr);
+            return result.node;
+        };
+
+        while ((node = retrieveNodes())) {
+            // it's faster to call the each callback in an array loop
+            // than in this while loop
+            elements.push(node);
+        }
+
+        elements.forEach((node) => {
+            eachCb(node);
+        });
+
+        doneCb();
+    }
+
+    forEachNode(whatToShow, each, filter, done = () => {}) {
+        const contexts = this.getContexts();
+        let open = contexts.length;
+        if (!open) {
+            done();
+        }
+        contexts.forEach((ctx) => {
+            this.iterateThroughNodes(whatToShow, ctx, each, filter, () => {
+                if (--open <= 0) {
+                    // call end all contexts were handled
+                    done();
+                }
+            });
+        });
+    }
+}
+
+export default Mark;

--- a/src/components/List/ListElement.tsx
+++ b/src/components/List/ListElement.tsx
@@ -18,7 +18,12 @@ export const ListElement = ({
 
     return (
         <PanelSectionRow>
-            <ButtonItem layout="below" onClick={handleClick}>
+            <ButtonItem
+                //@ts-ignore
+                disableNavSounds={true}
+                layout="below"
+                onClick={handleClick}
+            >
                 {displayText}
             </ButtonItem>
         </PanelSectionRow>

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -38,7 +38,7 @@ export const Nav = ({ serverApi }: DefaultProps) => {
     return useMemo(
         () =>
             pluginState !== 'games' ? (
-                <div style={{ flex: '0 1 auto', marginBottom: '10px' }}>
+                <div style={{ flex: '0 1 auto', padding: '0 10px' }}>
                     <Focusable
                         style={{
                             display: 'flex',
@@ -108,7 +108,7 @@ export const Nav = ({ serverApi }: DefaultProps) => {
                     )}
                 </div>
             ) : (
-                <div style={{ flex: '0 1 auto', marginBottom: '10px' }}>
+                <div style={{ flex: '0 1 auto', padding: '0 10px' }}>
                     <ToggleField
                         label="Enable Dark Mode?"
                         description={`Enable Dark Mode for Guides`}

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -31,52 +31,43 @@ export const Nav = ({ serverApi }: DefaultProps) => {
         dispatch({ type: ActionType.UPDATE_DARK_MODE, payload: result });
     };
 
-    const navButtonStyle = {
-        height: '40px',
-        width: '33%',
-        minWidth: '0',
-        display: 'inline-block',
-        verticalAlign: 'bottom',
-        padding: '10px 12px',
-        margin: '0 auto',
-    };
-    const childStyle = {
-        maxWidth: '33%',
+    const btnStyle = {
+        maxWidth: '32%',
         flexGrow: 1,
     };
     return useMemo(
         () =>
             pluginState !== 'games' ? (
                 <div style={{ flex: '0 1 auto', marginBottom: '10px' }}>
-                    <div
+                    <Focusable
                         style={{
-                            display: 'inline-block',
-                            width: '100%',
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            flexWrap: 'wrap',
                             marginBottom: '5px',
                         }}
                     >
-                        <Focusable>
-                            {pluginState !== 'results' && (
-                                <DialogButton
+                        {pluginState !== 'results' && (
+                            <DialogButton
+                                style={{
+                                    ...btnStyle,
+                                    minWidth: '0px',
+                                    marginRight: '5px',
+                                }}
+                                onClick={backToGames}
+                            >
+                                <FaHome
                                     style={{
-                                        ...navButtonStyle,
-                                        marginRight: '5px',
+                                        margin: '0 auto',
+                                        display: 'block',
                                     }}
-                                    onClick={backToGames}
-                                >
-                                    <FaHome
-                                        style={{
-                                            margin: '0 auto',
-                                            display: 'block',
-                                        }}
-                                    />
-                                </DialogButton>
-                            )}
-                            <DialogButton style={navButtonStyle} onClick={back}>
-                                Back
+                                />
                             </DialogButton>
-                        </Focusable>
-                    </div>
+                        )}
+                        <DialogButton style={btnStyle} onClick={back}>
+                            Back
+                        </DialogButton>
+                    </Focusable>
                     {pluginState == 'guide' && (
                         <Focusable
                             style={{
@@ -85,27 +76,29 @@ export const Nav = ({ serverApi }: DefaultProps) => {
                                 flexWrap: 'wrap',
                             }}
                         >
-                            <div style={{ ...childStyle, marginRight: '5px' }}>
-                                <DialogButton
-                                    style={{ minWidth: '0px' }}
-                                    onClick={() => {
-                                        Router.CloseSideMenus();
-                                        setTimeout(
-                                            () =>
-                                                Router.Navigate(
-                                                    '/deckfaqs-fullscreen'
-                                                ),
-                                            100
-                                        );
-                                    }}
-                                >
-                                    <BsArrowsFullscreen />
-                                </DialogButton>
-                            </div>
+                            <DialogButton
+                                style={{
+                                    ...btnStyle,
+                                    marginRight: '5px',
+                                    minWidth: '0px',
+                                }}
+                                onClick={() => {
+                                    Router.CloseSideMenus();
+                                    setTimeout(
+                                        () =>
+                                            Router.Navigate(
+                                                '/deckfaqs-fullscreen'
+                                            ),
+                                        100
+                                    );
+                                }}
+                            >
+                                <BsArrowsFullscreen />
+                            </DialogButton>
                             {currentGuide &&
                             currentGuide.guideToc!.length > 0 ? (
                                 <TocDropdown
-                                    style={childStyle}
+                                    style={{ ...btnStyle, minWidth: '160px' }}
                                     serverApi={serverApi}
                                 />
                             ) : (

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -49,6 +49,8 @@ export const Nav = ({ serverApi }: DefaultProps) => {
                     >
                         {pluginState !== 'results' && (
                             <DialogButton
+                                //@ts-ignore
+                                disableNavSounds={true}
                                 style={{
                                     ...btnStyle,
                                     minWidth: '0px',
@@ -64,7 +66,12 @@ export const Nav = ({ serverApi }: DefaultProps) => {
                                 />
                             </DialogButton>
                         )}
-                        <DialogButton style={btnStyle} onClick={back}>
+                        <DialogButton
+                            //@ts-ignore
+                            disableNavSounds={true}
+                            style={btnStyle}
+                            onClick={back}
+                        >
                             Back
                         </DialogButton>
                     </Focusable>
@@ -77,6 +84,8 @@ export const Nav = ({ serverApi }: DefaultProps) => {
                             }}
                         >
                             <DialogButton
+                                //@ts-ignore
+                                disableNavSounds={true}
                                 style={{
                                     ...btnStyle,
                                     marginRight: '5px',

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -10,6 +10,7 @@ import { FaHome } from 'react-icons/fa';
 import { AppContext } from '../../context/AppContext';
 import { ActionType } from '../../reducers/AppReducer';
 import { DefaultProps } from '../../utils';
+import { Search } from './Search';
 import { TocDropdown } from './TocDropdown';
 
 export const Nav = ({ serverApi }: DefaultProps) => {
@@ -32,7 +33,7 @@ export const Nav = ({ serverApi }: DefaultProps) => {
 
     const navButtonStyle = {
         height: '40px',
-        width: '49%',
+        width: '33%',
         minWidth: '0',
         display: 'inline-block',
         verticalAlign: 'bottom',
@@ -40,7 +41,7 @@ export const Nav = ({ serverApi }: DefaultProps) => {
         margin: '0 auto',
     };
     const childStyle = {
-        maxWidth: '49%',
+        maxWidth: '33%',
         flexGrow: 1,
     };
     return useMemo(
@@ -102,12 +103,14 @@ export const Nav = ({ serverApi }: DefaultProps) => {
                                 </DialogButton>
                             </div>
                             {currentGuide &&
-                                currentGuide.guideToc!.length > 0 && (
-                                    <TocDropdown
-                                        style={childStyle}
-                                        serverApi={serverApi}
-                                    />
-                                )}
+                            currentGuide.guideToc!.length > 0 ? (
+                                <TocDropdown
+                                    style={childStyle}
+                                    serverApi={serverApi}
+                                />
+                            ) : (
+                                <Search serverApi={serverApi} />
+                            )}
                         </Focusable>
                     )}
                 </div>

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -102,7 +102,7 @@ export const Nav = ({ serverApi }: DefaultProps) => {
                                     serverApi={serverApi}
                                 />
                             ) : (
-                                <Search serverApi={serverApi} />
+                                <Search />
                             )}
                         </Focusable>
                     )}

--- a/src/components/Nav/Search.tsx
+++ b/src/components/Nav/Search.tsx
@@ -1,9 +1,13 @@
-import { DialogButton, showModal } from 'decky-frontend-lib';
+import {
+    DialogButton,
+    QuickAccessTab,
+    Router,
+    showModal,
+} from 'decky-frontend-lib';
 import React, { useContext } from 'react';
 import { BsSearch, BsArrowBarDown, BsArrowBarUp } from 'react-icons/bs';
 import { AppContext } from '../../context/AppContext';
 import { ActionType } from '../../reducers/AppReducer';
-import { DefaultProps } from '../../utils';
 import { SearchModal } from './SearchModal';
 
 const childStyle = {
@@ -12,7 +16,11 @@ const childStyle = {
     padding: '0px',
 };
 
-export const Search = ({ serverApi: _serverApi }: DefaultProps) => {
+type SearchProps = {
+    fullScreen?: boolean;
+};
+
+export const Search = ({ fullScreen }: SearchProps) => {
     const {
         state: { search },
         dispatch,
@@ -26,6 +34,9 @@ export const Search = ({ serverApi: _serverApi }: DefaultProps) => {
                 searchText: result,
             },
         });
+        if (!fullScreen) {
+            Router.OpenQuickAccessMenu(QuickAccessTab.Decky);
+        }
     };
     return (
         <>

--- a/src/components/Nav/Search.tsx
+++ b/src/components/Nav/Search.tsx
@@ -6,7 +6,7 @@ import {
 } from 'decky-frontend-lib';
 import React, { useContext } from 'react';
 import { BsSearch, BsArrowBarDown, BsArrowBarUp } from 'react-icons/bs';
-import { AppContext } from '../../context/AppContext';
+import { AppContext, initSearchState } from '../../context/AppContext';
 import { ActionType } from '../../reducers/AppReducer';
 import { SearchModal } from './SearchModal';
 
@@ -45,11 +45,7 @@ export const Search = ({ fullScreen }: SearchProps) => {
                 onClick={() => {
                     dispatch({
                         type: ActionType.UPDATE_SEARCH,
-                        payload: {
-                            searchText: '',
-                            searchAnchorLength: 0,
-                            anchorIndex: 0,
-                        },
+                        payload: initSearchState,
                     });
                     showModal(<SearchModal setModalResult={handleResult} />);
                 }}

--- a/src/components/Nav/Search.tsx
+++ b/src/components/Nav/Search.tsx
@@ -1,19 +1,15 @@
 import { DialogButton, showModal } from 'decky-frontend-lib';
 import React, { useContext } from 'react';
+import { BsSearch, BsArrowBarDown, BsArrowBarUp } from 'react-icons/bs';
 import { AppContext } from '../../context/AppContext';
 import { ActionType } from '../../reducers/AppReducer';
 import { DefaultProps } from '../../utils';
 import { SearchModal } from './SearchModal';
 
-const navButtonStyle = {
-    height: '40px',
-    width: '33%',
-    minWidth: '0',
-    display: 'inline-block',
-    verticalAlign: 'bottom',
-    padding: '10px 12px',
-    flexGrow: 1,
-    //margin: '0 auto',
+const childStyle = {
+    flexGrow: '1',
+    minWidth: '0px',
+    padding: '0px',
 };
 
 export const Search = ({ serverApi: _serverApi }: DefaultProps) => {
@@ -23,9 +19,8 @@ export const Search = ({ serverApi: _serverApi }: DefaultProps) => {
     } = useContext(AppContext);
 
     const handleResult = (result: string) => {
-        console.log(`handleResult(${result})`);
         dispatch({
-            type: ActionType.UPDATE_SEARCH_TEXT,
+            type: ActionType.UPDATE_SEARCH,
             payload: {
                 ...search,
                 searchText: result,
@@ -33,13 +28,52 @@ export const Search = ({ serverApi: _serverApi }: DefaultProps) => {
         });
     };
     return (
-        <DialogButton
-            style={navButtonStyle}
-            onClick={() => {
-                showModal(<SearchModal setModalResult={handleResult} />);
-            }}
-        >
-            Search
-        </DialogButton>
+        <>
+            <DialogButton
+                style={{ ...childStyle, maxWidth: '32%', marginRight: '5px' }}
+                onClick={() => {
+                    dispatch({
+                        type: ActionType.UPDATE_SEARCH,
+                        payload: {
+                            searchText: '',
+                            searchAnchorLength: 0,
+                            anchorIndex: 0,
+                        },
+                    });
+                    showModal(<SearchModal setModalResult={handleResult} />);
+                }}
+            >
+                <BsSearch />
+            </DialogButton>
+            <DialogButton
+                style={{ ...childStyle, maxWidth: '10%', marginRight: '5px' }}
+                onClick={() => {
+                    const anchorIndex = search.anchorIndex - 1;
+                    anchorIndex >= 0 &&
+                        dispatch({
+                            type: ActionType.UPDATE_SEARCH,
+                            payload: { ...search, anchorIndex: anchorIndex },
+                        });
+                }}
+            >
+                <BsArrowBarUp />
+            </DialogButton>
+            <DialogButton
+                style={{ ...childStyle, maxWidth: '10%' }}
+                onClick={() => {
+                    const anchorIndex = search.anchorIndex + 1;
+                    anchorIndex < search.searchAnchorLength &&
+                        dispatch({
+                            type: ActionType.UPDATE_SEARCH,
+                            payload: {
+                                ...search,
+                                anchorIndex: anchorIndex,
+                            },
+                        });
+                }}
+            >
+                <BsArrowBarDown />
+            </DialogButton>
+        </>
     );
 };

--- a/src/components/Nav/Search.tsx
+++ b/src/components/Nav/Search.tsx
@@ -41,6 +41,8 @@ export const Search = ({ fullScreen }: SearchProps) => {
     return (
         <>
             <DialogButton
+                //@ts-ignore
+                disableNavSounds={true}
                 style={{ ...childStyle, maxWidth: '32%', marginRight: '5px' }}
                 onClick={() => {
                     dispatch({
@@ -53,6 +55,8 @@ export const Search = ({ fullScreen }: SearchProps) => {
                 <BsSearch />
             </DialogButton>
             <DialogButton
+                //@ts-ignore
+                disableNavSounds={true}
                 style={{ ...childStyle, maxWidth: '10%', marginRight: '5px' }}
                 onClick={() => {
                     const anchorIndex = search.anchorIndex - 1;
@@ -66,6 +70,8 @@ export const Search = ({ fullScreen }: SearchProps) => {
                 <BsArrowBarUp />
             </DialogButton>
             <DialogButton
+                //@ts-ignore
+                disableNavSounds={true}
                 style={{ ...childStyle, maxWidth: '10%' }}
                 onClick={() => {
                     const anchorIndex = search.anchorIndex + 1;

--- a/src/components/Nav/Search.tsx
+++ b/src/components/Nav/Search.tsx
@@ -1,0 +1,45 @@
+import { DialogButton, showModal } from 'decky-frontend-lib';
+import React, { useContext } from 'react';
+import { AppContext } from '../../context/AppContext';
+import { ActionType } from '../../reducers/AppReducer';
+import { DefaultProps } from '../../utils';
+import { SearchModal } from './SearchModal';
+
+const navButtonStyle = {
+    height: '40px',
+    width: '33%',
+    minWidth: '0',
+    display: 'inline-block',
+    verticalAlign: 'bottom',
+    padding: '10px 12px',
+    flexGrow: 1,
+    //margin: '0 auto',
+};
+
+export const Search = ({ serverApi: _serverApi }: DefaultProps) => {
+    const {
+        state: { search },
+        dispatch,
+    } = useContext(AppContext);
+
+    const handleResult = (result: string) => {
+        console.log(`handleResult(${result})`);
+        dispatch({
+            type: ActionType.UPDATE_SEARCH_TEXT,
+            payload: {
+                ...search,
+                searchText: result,
+            },
+        });
+    };
+    return (
+        <DialogButton
+            style={navButtonStyle}
+            onClick={() => {
+                showModal(<SearchModal setModalResult={handleResult} />);
+            }}
+        >
+            Search
+        </DialogButton>
+    );
+};

--- a/src/components/Nav/SearchModal.tsx
+++ b/src/components/Nav/SearchModal.tsx
@@ -14,7 +14,6 @@ type MyProps = ModalRootProps & {
 export const SearchModal = ({ closeModal, setModalResult }: MyProps) => {
     const [searchText, setSearchText] = useState('');
     const handleText = (e: React.ChangeEvent<HTMLInputElement>) => {
-        console.log(e.target.value);
         setSearchText(e.target.value);
     };
     const showData = () => {

--- a/src/components/Nav/SearchModal.tsx
+++ b/src/components/Nav/SearchModal.tsx
@@ -1,5 +1,5 @@
 import { ModalRootProps, TextField } from 'decky-frontend-lib';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { EmptyModal } from '../EmptyModal';
 
 type MyProps = ModalRootProps & {
@@ -14,6 +14,12 @@ export const SearchModal = ({ closeModal, setModalResult }: MyProps) => {
     const handleSubmit = () => {
         setModalResult && setModalResult(searchText);
     };
+    const textField = useRef<any>();
+
+    useEffect(() => {
+        //This will open up the virtual keyboard
+        textField.current?.element?.click();
+    }, []);
     return (
         <EmptyModal
             onCancel={() => {
@@ -22,7 +28,15 @@ export const SearchModal = ({ closeModal, setModalResult }: MyProps) => {
             closeModal={closeModal}
         >
             <form onSubmit={handleSubmit}>
-                <TextField label="Search" onChange={handleText} />
+                <TextField
+                    //@ts-ignore
+                    ref={textField}
+                    focusOnMount={true}
+                    label="Search"
+                    //@ts-ignore
+                    placeholder="Search the guide"
+                    onChange={handleText}
+                />
             </form>
         </EmptyModal>
     );

--- a/src/components/Nav/SearchModal.tsx
+++ b/src/components/Nav/SearchModal.tsx
@@ -1,0 +1,36 @@
+import {
+    ModalRootProps,
+    QuickAccessTab,
+    Router,
+    TextField,
+} from 'decky-frontend-lib';
+import React, { useState } from 'react';
+import { EmptyModal } from '../EmptyModal';
+
+type MyProps = ModalRootProps & {
+    setModalResult?(result: string): void;
+};
+
+export const SearchModal = ({ closeModal, setModalResult }: MyProps) => {
+    const [searchText, setSearchText] = useState('');
+    const handleText = (e: React.ChangeEvent<HTMLInputElement>) => {
+        console.log(e.target.value);
+        setSearchText(e.target.value);
+    };
+    const showData = () => {
+        setModalResult && setModalResult(searchText);
+        Router.OpenQuickAccessMenu(QuickAccessTab.Decky);
+    };
+    return (
+        <EmptyModal
+            onCancel={() => {
+                Router.OpenQuickAccessMenu(QuickAccessTab.Decky);
+            }}
+            closeModal={closeModal}
+        >
+            <form onSubmit={showData}>
+                <TextField label="Search" onChange={handleText} />
+            </form>
+        </EmptyModal>
+    );
+};

--- a/src/components/Nav/SearchModal.tsx
+++ b/src/components/Nav/SearchModal.tsx
@@ -1,9 +1,4 @@
-import {
-    ModalRootProps,
-    QuickAccessTab,
-    Router,
-    TextField,
-} from 'decky-frontend-lib';
+import { ModalRootProps, TextField } from 'decky-frontend-lib';
 import React, { useState } from 'react';
 import { EmptyModal } from '../EmptyModal';
 
@@ -16,18 +11,17 @@ export const SearchModal = ({ closeModal, setModalResult }: MyProps) => {
     const handleText = (e: React.ChangeEvent<HTMLInputElement>) => {
         setSearchText(e.target.value);
     };
-    const showData = () => {
+    const handleSubmit = () => {
         setModalResult && setModalResult(searchText);
-        Router.OpenQuickAccessMenu(QuickAccessTab.Decky);
     };
     return (
         <EmptyModal
             onCancel={() => {
-                Router.OpenQuickAccessMenu(QuickAccessTab.Decky);
+                handleSubmit();
             }}
             closeModal={closeModal}
         >
-            <form onSubmit={showData}>
+            <form onSubmit={handleSubmit}>
                 <TextField label="Search" onChange={handleText} />
             </form>
         </EmptyModal>

--- a/src/components/Nav/TocDropdown.tsx
+++ b/src/components/Nav/TocDropdown.tsx
@@ -43,6 +43,8 @@ export const TocDropdown = ({ serverApi, style }: TocDropdownProps) => {
     return (
         <div style={style}>
             <Dropdown
+                //@ts-ignore
+                disableNavSounds={true}
                 rgOptions={currentGuide?.guideToc ?? []}
                 strDefaultLabel="TOC"
                 selectedOption={currentGuide?.currentTocSection}

--- a/src/components/ScrollPanel.tsx
+++ b/src/components/ScrollPanel.tsx
@@ -1,0 +1,29 @@
+import { findModuleChild } from 'decky-frontend-lib';
+import { VFC, ReactNode, HTMLAttributes, RefAttributes } from 'react';
+
+//Unclear how many of these have an effect (also probably not exhaustive)
+interface ScrollPanelProps extends HTMLAttributes<HTMLDivElement> {
+    children: ReactNode;
+    scrollDirection?: 'x' | 'y' | 'both';
+    focusable?: boolean;
+    autoFocus?: boolean;
+    scrollStepPercent?: number;
+    scrollBehavior?: string;
+    noFocusRing?: boolean;
+    onOKButton?: (e: CustomEvent) => void;
+    onCancelButton?: (e: CustomEvent) => void;
+}
+
+export const ScrollPanel: any = findModuleChild((m) => {
+    if (typeof m !== 'object') return undefined;
+    for (let prop in m) {
+        if (
+            m[prop]?.render
+                ?.toString()
+                ?.includes(
+                    '["onOKButton","onCancelButton","navRef","focusable"]'
+                )
+        )
+            return m[prop];
+    }
+}) as VFC<ScrollPanelProps & RefAttributes<HTMLDivElement>>;

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -17,6 +17,11 @@ export type GuideContents = {
     anchor?: string;
 };
 
+export type GuideSearch = {
+    searchText: string;
+    searchIndex: number;
+};
+
 export type TAppState = {
     pluginState: PluginState;
     games: ListItem[];
@@ -26,6 +31,7 @@ export type TAppState = {
     darkMode: boolean;
     isLoading: boolean;
     currentGuide?: GuideContents;
+    search: GuideSearch;
 };
 
 type TAppContext = {
@@ -42,6 +48,7 @@ export const initialState: TAppState = {
     currentGuide: undefined,
     darkMode: false,
     isLoading: false,
+    search: { searchText: '', searchIndex: 0 },
 };
 
 export const AppContext = createContext<TAppContext>({

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -26,7 +26,7 @@ export type GuideSearch = {
 export const initSearchState: GuideSearch = {
     searchText: '',
     searchAnchorLength: 0,
-    anchorIndex: 0,
+    anchorIndex: -1,
 };
 
 export type TAppState = {

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -19,7 +19,8 @@ export type GuideContents = {
 
 export type GuideSearch = {
     searchText: string;
-    searchIndex: number;
+    searchAnchorLength: number;
+    anchorIndex: number;
 };
 
 export type TAppState = {
@@ -48,7 +49,7 @@ export const initialState: TAppState = {
     currentGuide: undefined,
     darkMode: false,
     isLoading: false,
-    search: { searchText: '', searchIndex: 0 },
+    search: { searchText: '', searchAnchorLength: 0, anchorIndex: 0 },
 };
 
 export const AppContext = createContext<TAppContext>({

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -23,6 +23,12 @@ export type GuideSearch = {
     anchorIndex: number;
 };
 
+export const initSearchState: GuideSearch = {
+    searchText: '',
+    searchAnchorLength: 0,
+    anchorIndex: 0,
+};
+
 export type TAppState = {
     pluginState: PluginState;
     games: ListItem[];
@@ -49,7 +55,7 @@ export const initialState: TAppState = {
     currentGuide: undefined,
     darkMode: false,
     isLoading: false,
-    search: { searchText: '', searchAnchorLength: 0, anchorIndex: 0 },
+    search: initSearchState,
 };
 
 export const AppContext = createContext<TAppContext>({

--- a/src/reducers/AppReducer.ts
+++ b/src/reducers/AppReducer.ts
@@ -2,7 +2,6 @@ import { ListItem } from '../components/List/List';
 import {
     GuideContents,
     GuideSearch,
-    initSearchState,
     PluginState,
     TAppState,
 } from '../context/AppContext';
@@ -131,7 +130,11 @@ export const appReducer = (state: TAppState, action: AppActions): TAppState => {
                 ...state,
                 isLoading: false,
                 currentGuide: action.payload,
-                search: initSearchState,
+                search: {
+                    searchText: '',
+                    searchAnchorLength: 0,
+                    anchorIndex: -1,
+                },
                 pluginState: 'guide',
             };
         case ActionType.BACK:

--- a/src/reducers/AppReducer.ts
+++ b/src/reducers/AppReducer.ts
@@ -17,7 +17,7 @@ export enum ActionType {
     BACK_TO_STATE,
     UPDATE_DARK_MODE,
     UPDATE_LOADING,
-    UPDATE_SEARCH_TEXT,
+    UPDATE_SEARCH,
 }
 
 export type AppActions =
@@ -34,7 +34,7 @@ export type AppActions =
     | UpdateSearchAction;
 
 export type UpdateSearchAction = {
-    type: ActionType.UPDATE_SEARCH_TEXT;
+    type: ActionType.UPDATE_SEARCH;
     payload: GuideSearch;
 };
 
@@ -167,7 +167,7 @@ export const appReducer = (state: TAppState, action: AppActions): TAppState => {
                 ...state,
                 isLoading: action.payload,
             };
-        case ActionType.UPDATE_SEARCH_TEXT:
+        case ActionType.UPDATE_SEARCH:
             return {
                 ...state,
                 search: action.payload,

--- a/src/reducers/AppReducer.ts
+++ b/src/reducers/AppReducer.ts
@@ -2,6 +2,7 @@ import { ListItem } from '../components/List/List';
 import {
     GuideContents,
     GuideSearch,
+    initSearchState,
     PluginState,
     TAppState,
 } from '../context/AppContext';
@@ -130,6 +131,7 @@ export const appReducer = (state: TAppState, action: AppActions): TAppState => {
                 ...state,
                 isLoading: false,
                 currentGuide: action.payload,
+                search: initSearchState,
                 pluginState: 'guide',
             };
         case ActionType.BACK:

--- a/src/reducers/AppReducer.ts
+++ b/src/reducers/AppReducer.ts
@@ -1,5 +1,10 @@
 import { ListItem } from '../components/List/List';
-import { GuideContents, PluginState, TAppState } from '../context/AppContext';
+import {
+    GuideContents,
+    GuideSearch,
+    PluginState,
+    TAppState,
+} from '../context/AppContext';
 
 export enum ActionType {
     UPDATE_PLUGIN_STATE,
@@ -12,6 +17,7 @@ export enum ActionType {
     BACK_TO_STATE,
     UPDATE_DARK_MODE,
     UPDATE_LOADING,
+    UPDATE_SEARCH_TEXT,
 }
 
 export type AppActions =
@@ -24,7 +30,13 @@ export type AppActions =
     | BackAction
     | BackToStateAction
     | UpdateDarkModeAction
-    | UpdateLoadingAction;
+    | UpdateLoadingAction
+    | UpdateSearchAction;
+
+export type UpdateSearchAction = {
+    type: ActionType.UPDATE_SEARCH_TEXT;
+    payload: GuideSearch;
+};
 
 export type UpdateLoadingAction = {
     type: ActionType.UPDATE_LOADING;
@@ -154,6 +166,11 @@ export const appReducer = (state: TAppState, action: AppActions): TAppState => {
             return {
                 ...state,
                 isLoading: action.payload,
+            };
+        case ActionType.UPDATE_SEARCH_TEXT:
+            return {
+                ...state,
+                search: action.payload,
             };
         default:
             return state;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -88,7 +88,7 @@ get_guide();
 `;
 
 async function delay(ms: number, state = null) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
         window.setTimeout(() => resolve(state), ms);
     });
 }


### PR DESCRIPTION
## DeckFAQs, a GameFAQs browser for the Steam Deck (v1.3)

### The scroll and search update!

-   Adds the ability to search plain-text guides in the quick access menu. Search is supported for all guides in fullscreen view. Search is case insensitive.
-   Adds scrolling of guides with the gamepad. Scrolling works with either the joystick or dpad. Guide must have focus (click the guide with the A button). Focus can be removed by pressing B.
-   _NOTE:_ This version (and any version >= 1.0.0) is not compatible with the original PluginLoader. You must use the "Decky Loader" which is the react based plugin loader
- Build size reduced with terser rollup plugin.