### PR TITLE
Dev/beta bugfixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "deckfaqs",
-    "version": "1.5.3",
+    "version": "1.6.0",
     "description": "GameFAQs browser for the Steam Deck",
     "scripts": {
         "build": "rollup -c"

--- a/package.json
+++ b/package.json
@@ -9,26 +9,26 @@
     "license": "MIT",
     "private": true,
     "devDependencies": {
-        "@rollup/plugin-commonjs": "^22.0.1",
+        "@rollup/plugin-commonjs": "^22.0.2",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.3.0",
         "@rollup/plugin-replace": "^4.0.0",
-        "@rollup/plugin-typescript": "^8.3.3",
-        "@types/dompurify": "^2.3.3",
-        "@types/react": "^17.0.47",
-        "@types/react-dom": "^18.0.5",
+        "@rollup/plugin-typescript": "^8.5.0",
+        "@types/dompurify": "^2.4.0",
+        "@types/react": "^17.0.53",
+        "@types/react-dom": "^18.0.11",
         "prettier": "2.7.1",
-        "rollup": "^2.75.7",
+        "rollup": "^2.79.1",
         "rollup-plugin-import-assets": "^1.1.1",
-        "tslib": "^2.4.0",
-        "typescript": "^4.7.4"
+        "tslib": "^2.5.0",
+        "typescript": "^4.9.5"
     },
     "dependencies": {
-        "decky-frontend-lib": "^3.18.7",
-        "dompurify": "^2.3.9",
-        "html-react-parser": "^3.0.0",
+        "decky-frontend-lib": "^3.18.11",
+        "dompurify": "^2.4.4",
+        "html-react-parser": "^3.0.9",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-icons": "^4.4.0"
+        "react-icons": "^4.7.1"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,103 +1,103 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@rollup/plugin-commonjs': ^22.0.1
+  '@rollup/plugin-commonjs': ^22.0.2
   '@rollup/plugin-json': ^4.1.0
   '@rollup/plugin-node-resolve': ^13.3.0
   '@rollup/plugin-replace': ^4.0.0
-  '@rollup/plugin-typescript': ^8.3.3
-  '@types/dompurify': ^2.3.3
-  '@types/react': ^17.0.47
-  '@types/react-dom': ^18.0.5
-  decky-frontend-lib: ^3.18.7
-  dompurify: ^2.3.9
-  html-react-parser: ^3.0.0
+  '@rollup/plugin-typescript': ^8.5.0
+  '@types/dompurify': ^2.4.0
+  '@types/react': ^17.0.53
+  '@types/react-dom': ^18.0.11
+  decky-frontend-lib: ^3.18.11
+  dompurify: ^2.4.4
+  html-react-parser: ^3.0.9
   prettier: 2.7.1
   react: ^18.2.0
   react-dom: ^18.2.0
-  react-icons: ^4.4.0
-  rollup: ^2.75.7
+  react-icons: ^4.7.1
+  rollup: ^2.79.1
   rollup-plugin-import-assets: ^1.1.1
-  tslib: ^2.4.0
-  typescript: ^4.7.4
+  tslib: ^2.5.0
+  typescript: ^4.9.5
 
 dependencies:
-  decky-frontend-lib: 3.18.7
-  dompurify: 2.3.9
-  html-react-parser: 3.0.0_react@18.2.0
+  decky-frontend-lib: 3.18.11
+  dompurify: 2.4.4
+  html-react-parser: 3.0.9_react@18.2.0
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
-  react-icons: 4.4.0_react@18.2.0
+  react-icons: 4.7.1_react@18.2.0
 
 devDependencies:
-  '@rollup/plugin-commonjs': 22.0.1_rollup@2.75.7
-  '@rollup/plugin-json': 4.1.0_rollup@2.75.7
-  '@rollup/plugin-node-resolve': 13.3.0_rollup@2.75.7
-  '@rollup/plugin-replace': 4.0.0_rollup@2.75.7
-  '@rollup/plugin-typescript': 8.3.3_g4qkabtmybowem44p7ts7jnbqm
-  '@types/dompurify': 2.3.3
-  '@types/react': 17.0.47
-  '@types/react-dom': 18.0.5
+  '@rollup/plugin-commonjs': 22.0.2_rollup@2.79.1
+  '@rollup/plugin-json': 4.1.0_rollup@2.79.1
+  '@rollup/plugin-node-resolve': 13.3.0_rollup@2.79.1
+  '@rollup/plugin-replace': 4.0.0_rollup@2.79.1
+  '@rollup/plugin-typescript': 8.5.0_bhcmvni67fkldpaxrtldxbogce
+  '@types/dompurify': 2.4.0
+  '@types/react': 17.0.53
+  '@types/react-dom': 18.0.11
   prettier: 2.7.1
-  rollup: 2.75.7
-  rollup-plugin-import-assets: 1.1.1_rollup@2.75.7
-  tslib: 2.4.0
-  typescript: 4.7.4
+  rollup: 2.79.1
+  rollup-plugin-import-assets: 1.1.1_rollup@2.79.1
+  tslib: 2.5.0
+  typescript: 4.9.5
 
 packages:
 
-  /@rollup/plugin-commonjs/22.0.1_rollup@2.75.7:
-    resolution: {integrity: sha512-dGfEZvdjDHObBiP5IvwTKMVeq/tBZGMBHZFMdIV1ClMM/YoWS34xrHFGfag9SN2ZtMgNZRFruqvxZQEa70O6nQ==}
+  /@rollup/plugin-commonjs/22.0.2_rollup@2.79.1:
+    resolution: {integrity: sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
       rollup: ^2.68.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.75.7
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 7.2.3
       is-reference: 1.2.1
       magic-string: 0.25.9
       resolve: 1.22.1
-      rollup: 2.75.7
+      rollup: 2.79.1
     dev: true
 
-  /@rollup/plugin-json/4.1.0_rollup@2.75.7:
+  /@rollup/plugin-json/4.1.0_rollup@2.79.1:
     resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.75.7
-      rollup: 2.75.7
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
+      rollup: 2.79.1
     dev: true
 
-  /@rollup/plugin-node-resolve/13.3.0_rollup@2.75.7:
+  /@rollup/plugin-node-resolve/13.3.0_rollup@2.79.1:
     resolution: {integrity: sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       rollup: ^2.42.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.75.7
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
       '@types/resolve': 1.17.1
-      deepmerge: 4.2.2
-      is-builtin-module: 3.1.0
+      deepmerge: 4.3.0
+      is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.1
-      rollup: 2.75.7
+      rollup: 2.79.1
     dev: true
 
-  /@rollup/plugin-replace/4.0.0_rollup@2.75.7:
+  /@rollup/plugin-replace/4.0.0_rollup@2.79.1:
     resolution: {integrity: sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.75.7
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
       magic-string: 0.25.9
-      rollup: 2.75.7
+      rollup: 2.79.1
     dev: true
 
-  /@rollup/plugin-typescript/8.3.3_g4qkabtmybowem44p7ts7jnbqm:
-    resolution: {integrity: sha512-55L9SyiYu3r/JtqdjhwcwaECXP7JeJ9h1Sg1VWRJKIutla2MdZQodTgcCNybXLMCnqpNLEhS2vGENww98L1npg==}
+  /@rollup/plugin-typescript/8.5.0_bhcmvni67fkldpaxrtldxbogce:
+    resolution: {integrity: sha512-wMv1/scv0m/rXx21wD2IsBbJFba8wGF3ErJIr6IKRfRj49S85Lszbxb4DCo8iILpluTjk2GAAu9CoZt4G3ppgQ==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
       rollup: ^2.14.0
@@ -107,14 +107,14 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.75.7
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
       resolve: 1.22.1
-      rollup: 2.75.7
-      tslib: 2.4.0
-      typescript: 4.7.4
+      rollup: 2.79.1
+      tslib: 2.5.0
+      typescript: 4.9.5
     dev: true
 
-  /@rollup/pluginutils/3.1.0_rollup@2.75.7:
+  /@rollup/pluginutils/3.1.0_rollup@2.79.1:
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
@@ -123,57 +123,57 @@ packages:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.1
-      rollup: 2.75.7
+      rollup: 2.79.1
     dev: true
 
-  /@types/dompurify/2.3.3:
-    resolution: {integrity: sha512-nnVQSgRVuZ/843oAfhA25eRSNzUFcBPk/LOiw5gm8mD9/X7CNcbRkQu/OsjCewO8+VIYfPxUnXvPEVGenw14+w==}
+  /@types/dompurify/2.4.0:
+    resolution: {integrity: sha512-IDBwO5IZhrKvHFUl+clZxgf3hn2b/lU6H1KaBShPkQyGJUQ0xwebezIPSuiyGwfz1UzJWQl4M7BDxtHtCCPlTg==}
     dependencies:
-      '@types/trusted-types': 2.0.2
+      '@types/trusted-types': 2.0.3
     dev: true
 
   /@types/estree/0.0.39:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
     dev: true
 
-  /@types/estree/0.0.52:
-    resolution: {integrity: sha512-BZWrtCU0bMVAIliIV+HJO1f1PR41M7NKjfxrFJwwhKI1KwhwOxYw1SXg9ao+CIMt774nFuGiG6eU+udtbEI9oQ==}
+  /@types/estree/1.0.0:
+    resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
     dev: true
 
-  /@types/node/18.0.0:
-    resolution: {integrity: sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==}
+  /@types/node/18.14.0:
+    resolution: {integrity: sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==}
     dev: true
 
   /@types/prop-types/15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
     dev: true
 
-  /@types/react-dom/18.0.5:
-    resolution: {integrity: sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==}
+  /@types/react-dom/18.0.11:
+    resolution: {integrity: sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==}
     dependencies:
-      '@types/react': 17.0.47
+      '@types/react': 17.0.53
     dev: true
 
-  /@types/react/17.0.47:
-    resolution: {integrity: sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==}
+  /@types/react/17.0.53:
+    resolution: {integrity: sha512-1yIpQR2zdYu1Z/dc1OxC+MA6GR240u3gcnP4l6mvj/PJiVaqHsQPmWttsvHsfnhfPbU2FuGmo0wSITPygjBmsw==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
-      csstype: 3.1.0
+      csstype: 3.1.1
     dev: true
 
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 18.0.0
+      '@types/node': 18.14.0
     dev: true
 
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
     dev: true
 
-  /@types/trusted-types/2.0.2:
-    resolution: {integrity: sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==}
+  /@types/trusted-types/2.0.3:
+    resolution: {integrity: sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==}
     dev: true
 
   /balanced-match/1.0.2:
@@ -200,16 +200,16 @@ packages:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
-  /csstype/3.1.0:
-    resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
+  /csstype/3.1.1:
+    resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
     dev: true
 
-  /decky-frontend-lib/3.18.7:
-    resolution: {integrity: sha512-IonBSr820XmA3xwNYpV2IjHa7Qn2yFiosxvm5lb4/1KifrlIrLjHMqdJDFscHAIljOzZoJy8fdaHVfpLS2Te8Q==}
+  /decky-frontend-lib/3.18.11:
+    resolution: {integrity: sha512-SLb3qWJc6CLNRqcbNyJsA8D6sXf7aix8/h6VqQTWjVmel6c3SkOR6b9KMvgFRzXumfRt7XGasBnZJmyCwH4BCQ==}
     dev: false
 
-  /deepmerge/4.2.2:
-    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
+  /deepmerge/4.3.0:
+    resolution: {integrity: sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -218,7 +218,7 @@ packages:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
-      entities: 4.3.1
+      entities: 4.4.0
     dev: false
 
   /domelementtype/2.3.0:
@@ -232,8 +232,8 @@ packages:
       domelementtype: 2.3.0
     dev: false
 
-  /dompurify/2.3.9:
-    resolution: {integrity: sha512-3zOnuTwup4lPV/GfGS6UzG4ub9nhSYagR/5tB3AvDEwqyy5dtyCM2dVjwGDCnrPerXifBKTYh/UWCGKK7ydhhw==}
+  /dompurify/2.4.4:
+    resolution: {integrity: sha512-1e2SpqHiRx4DPvmRuXU5J0di3iQACwJM+mFGE2HAkkK7Tbnfk9WcghcAmyWc9CRrjyRRUpmuhPUH6LphQQR3EQ==}
     dev: false
 
   /domutils/3.0.1:
@@ -244,8 +244,8 @@ packages:
       domhandler: 5.0.3
     dev: false
 
-  /entities/4.3.1:
-    resolution: {integrity: sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==}
+  /entities/4.4.0:
+    resolution: {integrity: sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==}
     engines: {node: '>=0.12'}
     dev: false
 
@@ -295,23 +295,23 @@ packages:
       function-bind: 1.1.1
     dev: true
 
-  /html-dom-parser/3.0.0:
-    resolution: {integrity: sha512-ZV/7ED1XK5H3MYz7rX6rZfRuXP4umRCn+QeVnqhFqAAVGKxwy/bXl06dh7/QDaR/CkNyZXh4Lrxx3MkPsdvVjA==}
+  /html-dom-parser/3.1.3:
+    resolution: {integrity: sha512-fI0yyNlIeSboxU+jnrA4v8qj4+M8SI9/q6AKYdwCY2qki22UtKCDTxvagHniECu7sa5/o2zFRdLleA67035lsA==}
     dependencies:
       domhandler: 5.0.3
       htmlparser2: 8.0.1
     dev: false
 
-  /html-react-parser/3.0.0_react@18.2.0:
-    resolution: {integrity: sha512-CwUhaSQc/6XR9MJx4yOS+vRHZP/FwKxNdmjU4/Y0EKWEM9C7uk6Ph0ce1Wz4DBKCM3uMwhD5KM3dZi1FJ9NfuQ==}
+  /html-react-parser/3.0.9_react@18.2.0:
+    resolution: {integrity: sha512-gOPZmaCMXNYu7Y9+58k2tLhTMXQ+QN8ctNFijzLuBxJaLZ6TsN+tUpN+MhbI+6nGaBCRGT2rpw6y/AqkTFZckg==}
     peerDependencies:
       react: 0.14 || 15 || 16 || 17 || 18
     dependencies:
       domhandler: 5.0.3
-      html-dom-parser: 3.0.0
+      html-dom-parser: 3.1.3
       react: 18.2.0
       react-property: 2.0.0
-      style-to-js: 1.1.1
+      style-to-js: 1.1.3
     dev: false
 
   /htmlparser2/8.0.1:
@@ -320,7 +320,7 @@ packages:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       domutils: 3.0.1
-      entities: 4.3.1
+      entities: 4.4.0
     dev: false
 
   /inflight/1.0.6:
@@ -338,15 +338,15 @@ packages:
     resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
     dev: false
 
-  /is-builtin-module/3.1.0:
-    resolution: {integrity: sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==}
+  /is-builtin-module/3.2.1:
+    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
     engines: {node: '>=6'}
     dependencies:
       builtin-modules: 3.3.0
     dev: true
 
-  /is-core-module/2.9.0:
-    resolution: {integrity: sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==}
+  /is-core-module/2.11.0:
+    resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
     dependencies:
       has: 1.0.3
     dev: true
@@ -358,7 +358,7 @@ packages:
   /is-reference/1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
     dependencies:
-      '@types/estree': 0.0.52
+      '@types/estree': 1.0.0
     dev: true
 
   /js-tokens/4.0.0:
@@ -420,8 +420,8 @@ packages:
       scheduler: 0.23.0
     dev: false
 
-  /react-icons/4.4.0_react@18.2.0:
-    resolution: {integrity: sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==}
+  /react-icons/4.7.1_react@18.2.0:
+    resolution: {integrity: sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==}
     peerDependencies:
       react: '*'
     dependencies:
@@ -443,17 +443,17 @@ packages:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
     hasBin: true
     dependencies:
-      is-core-module: 2.9.0
+      is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
-  /rollup-plugin-import-assets/1.1.1_rollup@2.75.7:
+  /rollup-plugin-import-assets/1.1.1_rollup@2.79.1:
     resolution: {integrity: sha512-u5zJwOjguTf2N+wETq2weNKGvNkuVc1UX/fPgg215p5xPvGOaI6/BTc024E9brvFjSQTfIYqgvwogQdipknu1g==}
     peerDependencies:
       rollup: '>=1.9.0'
     dependencies:
-      rollup: 2.75.7
+      rollup: 2.79.1
       rollup-pluginutils: 2.8.2
       url-join: 4.0.1
     dev: true
@@ -464,8 +464,8 @@ packages:
       estree-walker: 0.6.1
     dev: true
 
-  /rollup/2.75.7:
-    resolution: {integrity: sha512-VSE1iy0eaAYNCxEXaleThdFXqZJ42qDBatAwrfnPlENEZ8erQ+0LYX4JXOLPceWfZpV1VtZwZ3dFCuOZiSyFtQ==}
+  /rollup/2.79.1:
+    resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -480,16 +480,17 @@ packages:
 
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
     dev: true
 
-  /style-to-js/1.1.1:
-    resolution: {integrity: sha512-RJ18Z9t2B02sYhZtfWKQq5uplVctgvjTfLWT7+Eb1zjUjIrWzX5SdlkwLGQozrqarTmEzJJ/YmdNJCUNI47elg==}
+  /style-to-js/1.1.3:
+    resolution: {integrity: sha512-zKI5gN/zb7LS/Vm0eUwjmjrXWw8IMtyA8aPBJZdYiQTXj4+wQ3IucOLIOnF7zCHxvW8UhIGh/uZh/t9zEHXNTQ==}
     dependencies:
-      style-to-object: 0.3.0
+      style-to-object: 0.4.1
     dev: false
 
-  /style-to-object/0.3.0:
-    resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
+  /style-to-object/0.4.1:
+    resolution: {integrity: sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==}
     dependencies:
       inline-style-parser: 0.1.1
     dev: false
@@ -499,12 +500,12 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /tslib/2.4.0:
-    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+  /tslib/2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: true
 
-  /typescript/4.7.4:
-    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
+  /typescript/4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true

--- a/release.md
+++ b/release.md
@@ -1,4 +1,5 @@
-## DeckFAQs, a GameFAQs browser for the Steam Deck (v1.5.4)
+## DeckFAQs, a GameFAQs browser for the Steam Deck (v1.6.0)
 
--   Bump Decky Frontend Library version 
--   Remove code minifier
+-   Bump Decky Frontend Library version to fix issues with upcoming Steam Client changes
+-   Add reload guide feature
+-   Improve compatibility with some guides that would not load at all

--- a/src/SteamClient.d.ts
+++ b/src/SteamClient.d.ts
@@ -131,3 +131,13 @@ type InstallFolder = {
     bIsFixed: boolean;
     vecApps: App[];
 };
+
+type NonSteamGame = {
+    appid: number;
+    sort_as: string;
+    display_name: string;
+}
+
+declare namespace collectionStore {
+    const deckDesktopApps: {allApps: NonSteamGame[]};
+}

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -96,12 +96,12 @@ export const App = ({ serverApi }: DefaultProps) => {
             });
 
             // Non-Steam Games
-            const shortcuts = await SteamClient.Apps.GetAllShortcuts();
-            shortcuts.forEach(({ data: { strSortAs, strAppName } }) => {
-                if (!ignoreNonSteam.includes(strAppName)) {
-                    if (!runningGame && currentRunningGame == strAppName)
+            const shortcuts = collectionStore.deckDesktopApps.allApps;
+            shortcuts.forEach(({ sort_as, display_name } ) => {
+                if (!ignoreNonSteam.includes(display_name)) {
+                    if (!runningGame && currentRunningGame == display_name)
                         runningGame = currentRunningGame;
-                    games.push({ sortAsName: strSortAs, appName: strAppName });
+                    games.push({ sortAsName: sort_as, appName: display_name });
                 }
             });
             const apps = games.map((o) => o.appName);

--- a/src/components/Guide/Guide.tsx
+++ b/src/components/Guide/Guide.tsx
@@ -42,6 +42,13 @@ export const Guide = ({ serverApi, fullscreen }: GuideProps) => {
         replace: (domNode) => {
             if (
                 domNode instanceof Element &&
+                domNode.attribs &&
+                domNode.attribs.style
+            ) {
+                delete domNode.attribs.style;
+            }
+            if (
+                domNode instanceof Element &&
                 domNode.name === 'a' &&
                 domNode.attribs &&
                 domNode.attribs.href

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -10,9 +10,10 @@ import {
 import React, { useContext, useMemo } from 'react';
 import { BsArrowsFullscreen } from 'react-icons/bs';
 import { FaHome } from 'react-icons/fa';
-import { AppContext } from '../../context/AppContext';
+import { FiRotateCw } from 'react-icons/fi';
+import { AppContext, TableOfContentEntry } from '../../context/AppContext';
 import { ActionType } from '../../reducers/AppReducer';
-import { DefaultProps, gameSearch } from '../../utils';
+import { DefaultProps, gameSearch, getGuideHtml } from '../../utils';
 import { Search } from './Search';
 import { SearchModal } from './SearchModal';
 import { TocDropdown } from './TocDropdown';
@@ -25,6 +26,26 @@ export const Nav = ({ serverApi }: DefaultProps) => {
 
     const back = () => {
         dispatch({ type: ActionType.BACK });
+    };
+
+    const reload = () => {
+        if (currentGuide?.guideUrl) {
+            dispatch({ type: ActionType.UPDATE_LOADING, payload: true });
+            getGuideHtml(
+                currentGuide.guideUrl,
+                serverApi,
+                (result: string, toc: Array<TableOfContentEntry>) => {
+                    dispatch({
+                        type: ActionType.UPDATE_GUIDE,
+                        payload: {
+                            guideHtml: result,
+                            guideUrl: currentGuide?.guideUrl,
+                            guideToc: toc,
+                        },
+                    });
+                }
+            );
+        }
     };
 
     const backToGames = () => {
@@ -42,8 +63,9 @@ export const Nav = ({ serverApi }: DefaultProps) => {
     };
 
     const btnStyle = {
-        maxWidth: '32%',
+        maxWidth: '30%',
         flexGrow: 1,
+        minWidth: 0,
     };
     return useMemo(
         () =>
@@ -69,6 +91,21 @@ export const Nav = ({ serverApi }: DefaultProps) => {
                                 onClick={backToGames}
                             >
                                 <FaHome
+                                    style={{
+                                        margin: '0 auto',
+                                        display: 'block',
+                                    }}
+                                />
+                            </DialogButton>
+                        )}
+                        {pluginState === 'guide' && (
+                            <DialogButton
+                                //@ts-ignore
+                                disableNavSounds={true}
+                                style={btnStyle}
+                                onClick={reload}
+                            >
+                                <FiRotateCw
                                     style={{
                                         margin: '0 auto',
                                         display: 'block',
@@ -131,7 +168,9 @@ export const Nav = ({ serverApi }: DefaultProps) => {
                     <DialogButton
                         //@ts-ignore
                         disableNavSounds={true}
-                        style={{ ...btnStyle, marginBottom: '10px' }}
+                        style={{
+                            marginBottom: '10px',
+                        }}
                         onClick={() => {
                             showModal(
                                 <SearchModal

--- a/src/components/Nav/TocDropdown.tsx
+++ b/src/components/Nav/TocDropdown.tsx
@@ -24,6 +24,7 @@ export const TocDropdown = ({ serverApi, style }: TocDropdownProps) => {
                 payload: { ...currentGuide, anchor, currentTocSection: path },
             });
         } else {
+            dispatch({ type: ActionType.UPDATE_LOADING, payload: true });
             getGuideHtml(href, serverApi, (result: string) => {
                 if (path.indexOf('#') > 0) {
                     anchor = path.substring(path.indexOf('#') + 1);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -101,6 +101,8 @@ export const getGuideHtml = async (
     serverApi: ServerAPI,
     handleResult: Function
 ) => {
+    url = encodeURI(url);
+    console.log(url);
     const test = SteamClient.BrowserView.Create();
     let htmlResult = '';
     let toc = '';


### PR DESCRIPTION
## DeckFAQs, a GameFAQs browser for the Steam Deck (v1.6.0)

-   Bump Decky Frontend Library version to fix issues with upcoming Steam Client changes
-   Add reload guide feature
-   Indicate guide is loading when table of content navigates to a new page
-   Improve compatibility with some guides that would not load at all. Some guides try to set style on html elements which breaks the parser. I've change it to just not accept the styling for the time being. It doesn't seem to have that horrible of an effect on guides so I think it should be fine.